### PR TITLE
CI: Switch to lix-gha-installer-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         nixOpts: [
             { flag: "", tag: "nixos-unstable" },
             { flag: "--override-input nixpkgs https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz", tag: "nixos-25.11" },
-            { flag: "--override-input nixpkgs https://channels.ctrl-os.com/channel/ctrlos-24.05.tar.xz", tag: "nixos-24.04" },
+            { flag: "--override-input nixpkgs https://channels.ctrl-os.com/channel/ctrlos-24.05.tar.xz", tag: "ctrlos-24.05" },
           ]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The nix-quick-install-action action does not setup Nix “properly” with regard to running in daemon mode. It sets Nix up to run in single-user mode.

This has the consequece that there are more ambient impurities that can sneak into the builds, including for example the GECOS field of the default user on GitHub actions being empty. This, in turn, breaks the build of a Nixpkgs package (fixed in newer Nixpkgs).

We should be able to have total trust our CI, and using the quick and dirty install from nix-quick-install-action will not do.

Instead, use lix-gha-installer-action, which uses the upstream Lix installer to install Nix. This means that we can trust that this Nix install is setup properly, even if it takes a bit more time to do so.

* * *

This directly fixes the broken check on main, and in other PRs. The package in question (`python311Packages.pdm-backend`) fails due to that impurity, and since it needs to be built as a dependency to the tests.

* * *

This additionally fixes the release channel name for CTRL-OS. The wrong name and the wrong number snuck in.