### PR TITLE
Fix Github Action Cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 name: "Test"
 on:
-  pull_request:
   push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:            # For manual runs on branches
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -21,19 +24,30 @@ jobs:
             keep-outputs = true
             extra-trusted-public-keys = ctrl-os:baPzGxj33zp/P+GAIJXsr8ss9Law+qEEFViX1+flbv8=
             extra-substituters = https://cache.ctrl-os.com/
-      - name: Restore the nix store if available
-        uses: nix-community/cache-nix-action/restore@v6
-        id: nix-cache-restore
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v5
         with:
-          primary-key: ctrl-os-modules-${{ runner.os }}-${{ matrix.nixOpts.tag }}-${{ github.sha }}
-          restore-prefixes-first-match: ctrl-os-modules-${{ runner.os }}-${{ matrix.nixOpts.tag }}
+          path: .cache
+          key: cache-${{ matrix.nixOpts.tag }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            cache-${{ matrix.nixOpts.tag }}-${{ github.ref_name }}-
+            cache-${{ matrix.nixOpts.tag }}-
+      - name: Repopulate Nix Store
+        if: steps.cache.outputs.cache-hit
+        run: |
+          if [ -d .cache/nix-store ]; then
+            # Paths we built in earlier runs are not signed.
+            nix path-info --store file://$PWD/.cache/nix-store --all | nix copy --no-check-sigs --from file://$PWD/.cache/nix-store --stdin
+          else
+            echo No cache to restore.
+          fi
       - name: Build the Modules for ${{ matrix.nixOpts.tag }}
         run: nix -L flake check ${{ matrix.nixOpts.flag }}
-      - name: Store the Build Cache always
-        uses: nix-community/cache-nix-action/save@v6
-        if: always() && steps.nix-cache-restore.outputs.hit-primary-key != 'true'
-        id: nix-cache-save
-        with:
-          primary-key: ctrl-os-modules-${{ runner.os }}-${{ matrix.nixOpts.tag }}-${{ github.sha }}
-          purge: true
-          purge-last-accessed: "432000" # Lets keep he cache for 5 days after the last access
+      - name: Export Nix Store
+        if: always()
+        run: |
+          mkdir -p .cache/nix-store
+          # We never clear paths from the cache. Github will evict the
+          # cached file if it is too large (>10GB).
+          nix path-info --all | nix copy --to file://$PWD/.cache/nix-store --stdin


### PR DESCRIPTION
With the switch to the Lix installer action, caching the Nix store didn't work anymore. We fix this here by manually exporting the store to a cached directory.

The pipelines will also reuse caches from other branches (as long as they target the same channel). So hopefully this gives our CI the boost it needs.

One caveat: Exporting the cache with `nix copy` is pretty slow. I wish there was a way we could use `nix-store --export`, but [asking on Discourse](https://discourse.nixos.org/t/backup-and-restore-nix-store/74577/2) hasn't helped yet.

While I was here I also fixed the issue that jobs may run twice.

Testing done:
- [x] Checked whether caches are successfully saved
- [x] Checked whether caches are successfully re-used
