### PR TITLE
packages/scl: Fix build

### DIFF
--- a/packages/scl.nix
+++ b/packages/scl.nix
@@ -8,11 +8,11 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "scl-management";
-  version = "0.1.0";
+  version = "unstable-2026-01-09";
   src = fetchFromGitLab {
     owner = "alasca.cloud";
     repo = "scl/scl-management";
-    rev = "main";
+    rev = "8839d1b09078bbcf32105d5807a7757ae69aeab7";
     hash = "sha256-KeUAdZzQPbROD9uM//EM/h1nKlEA0UaVS/03yicMrMA=";
   };
   cargoHash = "sha256-i65FRftT+5MMQevD5r093voHvCeQPWNlQUuSzh94VVc=";


### PR DESCRIPTION
Two issues:

 - Moving ref (`main`)
 - Version number for an untagged version

The latter is minor, though all current commits seem to be on `0.1.0`, so the version number is "wrong" for a Nixpkgs-like usage.

How did I get to that revision ID? I guessed! I looked at the commit date (2026-01-16), and at the the commits on the `main` branch in the repo. Found something older than the commit, and which looked *most plausible*. This turned out to be my first guess.

We know this is *correct* because the FOD hashes the *contents* of the checked out repository. If the contents differed, the hash hash would differ, and this would be failing (as it was).