### PR TITLE
ci: allow merge queues to start workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:            # For manual runs on branches
 jobs:
   tests:


### PR DESCRIPTION
See [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue). If we don't include this merge queues stay stuck.